### PR TITLE
update/v041~1

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -75,7 +75,7 @@ interfaces:
       - http
 dependencies:
   bitcoind:
-    version: ">=0.23.0.1 <31.0.0"
+    version: ">=0.23.0.1 <30.0.0"
     requirement:
       type: required
     description: Used to subscribe to new block events from a full archival node.


### PR DESCRIPTION
Ensure user is warned v30+ won't work as legacy wallets have been deprecated (at least in Core)